### PR TITLE
Adding guidelines for content reviewers

### DIFF
--- a/handbook_reviewer_guidelines.md
+++ b/handbook_reviewer_guidelines.md
@@ -20,6 +20,6 @@ This document contains the guidelines for anyone reviewing content for the Opera
 - [ ] Content meets the [style guidelines](style_guide.md)
   - Complete has a lower standard than “complete” for user-facing documentation, as per the Community Handbook style guide.
 - [ ] Reviewer feels the content is complete/accurate and approves it
-=== To enter ‘Done’ (decider = editor/reviewer & writer)
+=== To enter ‘Done’ (decider = reviewer & writer)
 - [ ] The writer and reviewer both agree that this version of content is finished or good-enough and ready to publish
 - [ ] The content is merged to the Community Handbook repository

--- a/handbook_reviewer_guidelines.md
+++ b/handbook_reviewer_guidelines.md
@@ -1,0 +1,25 @@
+This document contains the guidelines for anyone reviewing content for the Operate First Community Handbook.
+
+== Styling content
+
+
+== Criteria for each column to progress to the next column:
+=== To enter ‘Proposed content’
+- [ ] An issue or PR is made and assigned to the ‘Community Handbook’ project
+- [ ] To enter “Content in progress” (decider = reviewer)
+- [ ] Full idea
+- [ ] For issues, template is completely filled out
+- [ ] Proposed idea is understood by a reviewer
+- [ ] Reviewer accepts the idea and confirms it should be worked on (communication done through comments)
+- [ ] For issues, at least one person is assigned to work on it
+=== To enter “Review in progress” (decider = writer)
+- [ ] Writer (assignee) has worked on content / solution
+- [ ] Writer feels the content is ready for review
+=== To enter “Reviewer approved” (decider = reviewer)
+- [ ] Reviewer has fully reviewed the content, which may involve a series of suggestions and improvements
+- [ ] Content meets the [style guidelines](style_guide.md)
+  - Complete has a lower standard than “complete” for user-facing documentation, as per the Community Handbook style guide.
+- [ ] Reviewer feels the content is complete/accurate and approves it
+=== To enter ‘Done’ (decider = editor/reviewer & writer)
+- [ ] The writer and reviewer both agree that this version of content is finished or good-enough and ready to publish
+- [ ] The content is merged to the Community Handbook repository

--- a/handbook_reviewer_guidelines.md
+++ b/handbook_reviewer_guidelines.md
@@ -6,7 +6,7 @@ This document contains the guidelines for anyone reviewing content for the Opera
 == Criteria for each column to progress to the next column:
 === To enter ‘Proposed content’
 - [ ] An issue or PR is made and assigned to the ‘Community Handbook’ project
-- [ ] To enter “Content in progress” (decider = reviewer)
+=== To enter “Content in progress” (decider = reviewer)
 - [ ] Full idea
 - [ ] For issues, template is completely filled out
 - [ ] Proposed idea is understood by a reviewer


### PR DESCRIPTION
- Includes critera for moving between columns in project board at https://github.com/orgs/operate-first/projects/20
- Will grow to include all that a reviewer needs to know when reviewing and approving content for the Community Handbook

Signed-off-by: Karsten Wade <kwade@redhat.com>