### PR TITLE
Updates to readme/reviewer_guidelines and new request-repo guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,29 +1,31 @@
-# Community Handbook
+# Operate First Community Handbook
 
-## Welcome to the Community Handbook for Operate First!
+## Welcome to the xommunity handbook!
 
 The Community Handbook is intended to serve as a resource for all Operate First community contributors.
 It contains documentation on how to perform contributor-related tasks and encourages input and contributions from the community.
 The covenant of the Community Handbook is that if contributors must figure out a task for themselves, they should submit that solution to the handbook for the benefit of future contributors.
 
-## How to Contribute
+## How to contribute
 
 We welcome the Operate First community to contribute to the handbook!
 There are multiple ways to contribute:
-1. Create an issue in our [GitHub repository](https://github.com/operate-first/community-handbook)
-1. Create a pull request (PR) directly against the repository
-1. Label an issue or PR from another part of the project to identify as part of the Community Handbook
+1. Create an issue in our [GitHub repository](https://github.com/operate-first/community-handbook).
+1. Create a pull request (PR) directly against the repository.
+1. Label an issue or PR from another part of the project to identify as part of the Community Handbook.
 
-After creating an issue or PR, assign it to the project ‘Community Handbook’.
-This will cause it to automatically appear in the Community Handbook [project board](https://github.com/orgs/operate-first/projects/20) as a card under the column ‘Proposed content’.
+After creating an issue/PR, please add it to the Community Handbook project.
+You can follow [these directions](https://docs.github.com/en/issues/organizing-your-work-with-project-boards/tracking-work-with-project-boards/adding-issues-and-pull-requests-to-a-project-board#adding-issues-and-pull-requests-to-a-project-board-from-the-sidebar) to do so.
+After connecting to the project, the issue/PR will appear as a card in the Community Handbook [project board](https://github.com/orgs/operate-first/projects/20) under the column **Proposed content**.
 
 Next, we will begin the process of improving the documentation.
-The card moves between columns as the editing and review process progresses; for details on how the review process works, including the criteria to move between columns, refer to the [reviewer guidelines](handbook_reviewer_guidelines.md).
+The card moves between columns as the editing and review process progresses; for details on how the process works, including the criteria to move between columns, refer to the [reviewer guidelines](handbook_reviewer_guidelines.md).
 
 ### Creating an issue to contribute
-To create an issue, select ‘new issue’. If applicable, select the appropriate template:
-* The ‘Missing documentation’ template: if you have discovered a task for which no documentation currently exists in the handbook
-* The ‘Poor documentation’ template: if you have noticed any kind of errors or mistakes in existing documentation, or if you wish for existing documentation to improve in some way
+To create an issue, select **Issues** then **New issue**. If applicable, select the appropriate template:
+* The **Missing documentation** template: if you have discovered a task for which no documentation currently exists in the handbook.
+* The **Poor documentation** template: if you have noticed any kind of errors or mistakes in existing documentation, or if you wish for existing documentation to improve in some way.
+
 If neither of these templates apply, you can create an issue from scratch.
 If you’re interested in working on the solution, please assign yourself to the issue.
 Anyone who wishes to be involved in a particular issue may assign themselves to it.

--- a/handbook_reviewer_guidelines.md
+++ b/handbook_reviewer_guidelines.md
@@ -1,25 +1,29 @@
-This document contains the guidelines for anyone reviewing content for the Operate First Community Handbook.
+# Handbook reviewer guidelines
 
-== Styling content
+**This document contains the guidelines for anyone contributing or reviewing content for the Operate First Community Handbook.**
 
+## Styling content
 
-== Criteria for each column to progress to the next column:
-=== To enter ‘Proposed content’
-- [ ] An issue or PR is made and assigned to the ‘Community Handbook’ project
-=== To enter “Content in progress” (decider = reviewer)
-- [ ] Full idea
+TBD
+
+## Criteria for the project board columns
+
+### To enter *Proposed content*
+- [ ] An issue or PR is made and assigned to the Community Handbook project
+### To enter *Content in progress* (decider = reviewer)
+- [ ] Fully-formed idea
 - [ ] For issues, template is completely filled out
 - [ ] Proposed idea is understood by a reviewer
-- [ ] Reviewer accepts the idea and confirms it should be worked on (communication done through comments)
+- [ ] Reviewer accepts the idea and confirms it should be worked on (by communicating through comments)
 - [ ] For issues, at least one person is assigned to work on it
-=== To enter “Review in progress” (decider = writer)
-- [ ] Writer (assignee) has worked on content / solution
+### To enter *Review in progress* (decider = writer)
+- [ ] Writer (assignee) has worked on the content / solution
 - [ ] Writer feels the content is ready for review
-=== To enter “Reviewer approved” (decider = reviewer)
+### To enter *Reviewer approved* (decider = reviewer)
 - [ ] Reviewer has fully reviewed the content, which may involve a series of suggestions and improvements
 - [ ] Content meets the [style guidelines](style_guide.md)
-  - Complete has a lower standard than “complete” for user-facing documentation, as per the Community Handbook style guide.
+  - Content is held to a lower standard than user-facing documentation, as per the Community Handbook style guide.
 - [ ] Reviewer feels the content is complete/accurate and approves it
-=== To enter ‘Done’ (decider = reviewer & writer)
-- [ ] The writer and reviewer both agree that this version of content is finished or good-enough and ready to publish
+### To enter *Done* (decider = reviewer & writer)
+- [ ] The writer and reviewer agree that this version of content is finished or good-enough and ready to publish
 - [ ] The content is merged to the Community Handbook repository

--- a/request_a_repository.md
+++ b/request_a_repository.md
@@ -1,0 +1,13 @@
+# How to Request a New Repository
+
+To request a new repository in the Operate First organization, you must open an issue in the [common repository][1].
+
+1. Select **New issue**
+1. Click **Get started** next to Repository creation
+1. Fill out the issue template
+1. Select **Submit new issue**
+
+If you have any questions or need additional help, please post a message in the `#support` channel on the [Operate First slack][2].
+
+[1]: https://github.com/operate-first/common/issues
+[2]: https://app.slack.com/client/T01SKMNPRUG/C01RMPVUUK1/thread/C01RMPVUUK1-1625672268.339500


### PR DESCRIPTION
This pr:
* makes some improvements to the readme.md and handbook_reviewer_guidelines.md
* adds a new how-to guide for requesting a repo in the org: request_a_repository.md
* updates the handbook_reviewer_guidelines document so it renders correctly