### PR TITLE
Temp reduction for bootstrapping repo

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,23 +1,23 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-  - durandom
-  - tumido
-  - HumairAK
+#  - durandom
+#  - tumido
+#  - HumairAK
   - quaid
   - margarethaley
 
 reviewers:
-  - durandom
-  - oindrillac
-  - tumido
-  - HumairAK
-  - 4n4nd
-  - harshad16
-  - hemajv
-  - goern
-  - HumairAK
-  - tumido
-  - larsks
+#  - durandom
+#  - oindrillac
+#  - tumido
+#  - HumairAK
+#  - 4n4nd
+#  - harshad16
+#  - hemajv
+#  - goern
+#  - HumairAK
+#  - tumido
+#  - larsks
   - quaid
   - margarethaley


### PR DESCRIPTION
- Removing all approvers/reviewers from the community-handbook repo for a short period, probably less than a week.
- The problem is a bit 'chicken-and-egg':  we need to finish the reviewer guidelines before we can ask and expect reviews for this repo.
  - While we finish those reviewer guidelines, we also are building out other parts of the repo.
  - It's not fair to ask people to review documentation content without a reviewers guide, style guide, or even being given an introduction to the project!
- We want to use the proper pull request process for all work here.
  - By temporarily reducing the OWNERS file, a smaller group of us can reduce the noise of adding and removing all the rest of you as approvers/reviewers before the repo is ready for your reviews.

Signed-off by: Karsten Wade <kwade@redhat.com> <quaid@iquaid.org>