### PR TITLE
Beginners guide

### DIFF
--- a/contributing/beginners-get-started.md
+++ b/contributing/beginners-get-started.md
@@ -1,0 +1,35 @@
+# Beginner's guide to getting started as a contributor
+
+If you're looking to become a handbook contributor but aren't sure where to start, you've come to the right place.
+
+## Good first contributions to the [handbook repository][1]:
+* Fix a typo by making a pull request (PR) against the repo
+* Flag documentation that is confusing or needs improvement: select **Issues** > **New issue** > **Poor documentation**
+* Create an issue for any documentation that should be added to the handbook: select **Issues** > **New issue** > **Missing documentation**
+
+## Resources
+
+### Operate First
+* Check out the [website][7] for insights on the initiative
+* Visit the [Youtube channel][8] and [Twitter][9] for recent content and updates from the team
+
+### Github
+* [Understanding the GitHub flow][4]
+* [Creating PRs in GitHub][2]
+
+> Please note: when working on content for the handbook repo, we request that you [create a fork][5] (or copy) of the repo first.
+> Then, create a branch on your fork from which you will create/modify content, and follow the GitHub flow.
+
+### Other
+* Guide to [writing in Markdown][3], the mockup language we use for handbook documentation
+* [Open Source Guides: How to Contribute to Open Source][6]
+
+[1]: https://github.com/operate-first/community-handbook
+[2]: https://docs.github.com/en/github/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request
+[3]: https://www.markdownguide.org/
+[4]: https://guides.github.com/introduction/flow/
+[5]: https://docs.github.com/en/get-started/quickstart/fork-a-repo
+[6]: https://opensource.guide/how-to-contribute/
+[7]: https://www.operate-first.cloud/
+[8]: https://www.youtube.com/channel/UCe87bwqlGoBQs2RvMQZ5_sg
+[9]: https://twitter.com/OperateFirst


### PR DESCRIPTION
This pr adds beginners-get-started.md to the contributing folder. The file is intended to provide a few simple ideas for contributing to the handbook, as well as point out to other potentially helpful resources. The purpose of this addition to the handbook is to make contributing more accessible, specifically for anyone who is interested in the work but lacks experience working on open source projects.

Resolves https://github.com/operate-first/community-handbook/issues/20